### PR TITLE
fix: delete a tag

### DIFF
--- a/apps/chat/components/features/landing/sns/sns-list.tsx
+++ b/apps/chat/components/features/landing/sns/sns-list.tsx
@@ -54,15 +54,13 @@ export function SNSList({ list }: SNSListProps) {
             whileTap={{ scale: 0.9 }}
             target="_blank"
           >
-            <a href={sns.url}>
-              <motion.img
-                src={sns.imgUrl}
-                alt={sns.name}
-                className="h-4 w-4 md:h-6 md:w-6"
-                whileHover={{ rotate: 360 }}
-                transition={{ duration: 0.5 }}
-              />
-            </a>
+            <motion.img
+              src={sns.imgUrl}
+              alt={sns.name}
+              className="h-4 w-4 md:h-6 md:w-6"
+              whileHover={{ rotate: 360 }}
+              transition={{ duration: 0.5 }}
+            />
           </MotionLink>
         ))}
       </motion.nav>


### PR DESCRIPTION
### Description
The `MotionLink` tag was nested with the `a` tag, causing an error. 
Therefore, the a tag was removed to resolve the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Streamlined the social media list display by simplifying the clickable navigation, ensuring that hover and transition animations remain smooth and engaging for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->